### PR TITLE
Correct test name.

### DIFF
--- a/test_data_setup.py
+++ b/test_data_setup.py
@@ -26,5 +26,5 @@ class DataSetupTests(TestCase):
 
 
 class PlotlyFunctionsTests(TestCase):
-    def basic_test(self):
+    def test_basic(self):
         basic_test()


### PR DESCRIPTION
TestCase methods must be neamed`test_...` to be discoverable by the runner.